### PR TITLE
Display hostname with example app

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -4,5 +4,7 @@ set :port, ENV["PORT"] || 5000
 
 get '/' do
   whom = ENV["POWERED_BY"] || "Deis!"
-  "Powered by " + whom + "\n"
+  container = `hostname`.strip || "unknown"
+  "Powered by " + whom + "\nRunning on container ID " + container + "\n"
+
 end


### PR DESCRIPTION
This is a trivial addition to show the container ID (hostname) with the example app. It can be used to demonstrate application scaling:

``` console
$ deis ps:scale web=3
Scaling processes... but first, coffee!
done in 7s
=== jiggly-umbrella Processes

--- web:
web.1 up (v4)
web.2 up (v4)
web.3 up (v4)
$ curl -s http://jiggly-umbrella.dev.rovid.io
Powered by Deis!
Running on container ID 7322d0ffbcac
$ curl -s http://jiggly-umbrella.dev.rovid.io
Powered by Deis!
Running on container ID 13e7e3c1c24d
$ curl -s http://jiggly-umbrella.dev.rovid.io
Powered by Deis!
Running on container ID eee0faf14518
```
