### PR TITLE
remove unneccessary newline at the end of method

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -6,5 +6,4 @@ get '/' do
   whom = ENV["POWERED_BY"] || "Deis!"
   container = `hostname`.strip || "unknown"
   "Powered by " + whom + "\nRunning on container ID " + container + "\n"
-
 end


### PR DESCRIPTION
as ruby always returns the last statement, which is also what sinatra relies on. it's "best practice" to have the last statement on the last line of a method.