### PR TITLE
feat(*): use puma as webserver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'http://rubygems.org'
 ruby '2.3.1'
 gem 'sinatra'
+gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    puma (3.6.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -14,6 +15,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  puma
   sinatra
 
 RUBY VERSION

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec ruby web.rb -p ${PORT:-5000}
+web: bundle exec puma -C config/puma.rb

--- a/README.md
+++ b/README.md
@@ -23,16 +23,18 @@ Starting build... but first, coffee!
        Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
        Fetching gem metadata from http://rubygems.org/..........
        Fetching version metadata from http://rubygems.org/..
-       Using bundler 1.11.2
-       Installing rack 1.6.4
        Installing tilt 2.0.5
+       Installing puma 3.6.0 with native extensions
+       Installing rack 1.6.4
+       Using bundler 1.11.2
        Installing rack-protection 1.5.3
        Installing sinatra 1.4.7
-       Bundle complete! 1 Gemfile dependency, 5 gems now installed.
+       Bundle complete! 2 Gemfile dependencies, 6 gems now installed.
        Gems in the groups development and test were not installed.
        Bundled gems are installed into ./vendor/bundle.
-       Bundle completed (2.04s)
+       Bundle completed (4.87s)
        Cleaning up the bundler cache.
+-----> Writing config/database.yml to read from DATABASE_URL
 
 -----> Discovering process types
        Procfile declares types -> web

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,2 @@
+require './web'
+run Sinatra::Application

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,9 @@
+workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+threads_count = Integer(ENV['MAX_THREADS'] || 5)
+threads threads_count, threads_count
+
+preload_app!
+
+rackup      DefaultRackup
+port        ENV['PORT']     || 5000
+environment ENV['RACK_ENV'] || 'development'


### PR DESCRIPTION
You would **never** want to use WEBrick on a deployed app. It is single threaded and single process, meaning that it can only serve 1 request as a time.

Source: https://devcenter.heroku.com/articles/ruby-default-web-server

As an example app, we don't want to show bad practices like this.

Instead, we should switch to using the heroku recommended webserver, `puma` and their recommended `puma` configuration.  