### PR TITLE
chore(*): update ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'http://rubygems.org'
-ruby '2.3.1'
+ruby '2.4.1'
 gem 'sinatra'
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ DEPENDENCIES
   sinatra
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.4.1p111
 
 BUNDLED WITH
-   1.11.2
+   1.15.0


### PR DESCRIPTION
It's because latest ruby buildpack [no longer supports ruby version 2.3.1](https://devcenter.heroku.com/articles/ruby-support#supported-runtimes).